### PR TITLE
Vagrant up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .vagrant
-
+site.retry

--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Install apache via apt
   apt: name={{ item }} update_cache=yes
-  sudo: true
+  become_method: sudo
   with_items:
      - apache2
      - libapache2-mod-auth-mysql 

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Install base packages
   apt: name={{ item }} update_cache=yes
-  sudo: true
+  become_method: sudo
   with_items:
      - git
      - mysql-client

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -5,5 +5,5 @@
   apt: name={{ item }} update_cache=yes
   sudo: true
   with_items:
-     - git	
+     - git
      - mysql-client

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Install MySQL server
   apt: name={{ item }} update_cache=yes cache_valid_time=3600 state=present
-  sudo: yes
+  become_method: sudo
   with_items:
     - python-mysqldb
     - mysql-server


### PR DESCRIPTION
Added site.retry to `.gitignore` for hygiene. 

Eliminated the deprecation warning about how Ansible wants to assume root privs via sudo.